### PR TITLE
[fix] 兼容目标函数携带注解参数

### DIFF
--- a/lancet-weaver/src/main/java/me/ele/lancet/weaver/internal/asm/MethodChain.java
+++ b/lancet-weaver/src/main/java/me/ele/lancet/weaver/internal/asm/MethodChain.java
@@ -13,11 +13,14 @@ import me.ele.lancet.weaver.internal.util.PrimitiveUtil;
 import me.ele.lancet.weaver.internal.util.TypeUtil;
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -41,6 +44,9 @@ public class MethodChain {
 
     private Map<String, FieldEntity> fieldMap;
     private Map<String, Invoker> invokerMap = new HashMap<>();
+
+    private List<AnnotationNode> annotations = new ArrayList<>();
+    private List<List<AnnotationNode>> parameterAnnotations = new ArrayList<>();
 
 
     public MethodChain(String className, ClassVisitor base, Graph graph) {
@@ -81,6 +87,25 @@ public class MethodChain {
         head(access, TypeUtil.isStatic(access) ? Opcodes.INVOKESTATIC : Opcodes.INVOKESPECIAL, owner, name, desc);
     }
 
+    /**
+     * 收集原方法的注解信息
+     */
+    public void collectAnnotations(MethodNode originalMethod) {
+        if (originalMethod.visibleAnnotations != null) {
+            this.annotations.addAll(originalMethod.visibleAnnotations);
+        }
+        if (originalMethod.invisibleAnnotations != null) {
+            this.annotations.addAll(originalMethod.invisibleAnnotations);
+        }
+        // 收集参数注解
+        if (originalMethod.visibleParameterAnnotations != null) {
+            for (List<AnnotationNode> paramAnnos : originalMethod.visibleParameterAnnotations) {
+                if (paramAnnos != null) {
+                    this.parameterAnnotations.add(new ArrayList<>(paramAnnos));
+                }
+            }
+        }
+    }
 
     public void next(String className, int access, String name, String desc, MethodNode node, ClassVisitor cv) {
         String[] exs = (String[]) node.exceptions.toArray(new String[0]);
@@ -149,6 +174,30 @@ public class MethodChain {
 
     public void fakePreMethod(String className, int access, String name, String desc, String signature, String[] exceptions) {
         MethodVisitor mv = base.visitMethod(access, name, desc, null, exceptions);
+
+        // 注解到新方法
+        for (AnnotationNode anno : annotations) {
+            AnnotationVisitor av = mv.visitAnnotation(anno.desc, true);
+            if (av != null && anno.values != null) {
+                for (int i = 0; i < anno.values.size(); i += 2) {
+                    av.visit((String) anno.values.get(i), anno.values.get(i + 1));
+                }
+                av.visitEnd();
+            }
+        }
+
+        // 参数注解
+        for (int i = 0; i < parameterAnnotations.size(); i++) {
+            for (AnnotationNode paramAnno : parameterAnnotations.get(i)) {
+                AnnotationVisitor av = mv.visitParameterAnnotation(i, paramAnno.desc, true);
+                if (av != null && paramAnno.values != null) {
+                    for (int j = 0; j < paramAnno.values.size(); j += 2) {
+                        av.visit((String) paramAnno.values.get(j), paramAnno.values.get(j + 1));
+                    }
+                    av.visitEnd();
+                }
+            }
+        }
 
         createMethod(access, desc, head.action()).accept(mv);
 

--- a/lancet-weaver/src/main/java/me/ele/lancet/weaver/internal/asm/classvisitor/InsertClassVisitor.java
+++ b/lancet-weaver/src/main/java/me/ele/lancet/weaver/internal/asm/classvisitor/InsertClassVisitor.java
@@ -65,11 +65,15 @@ public class InsertClassVisitor extends LinkedClassVisitor {
                     Log.tag("transform").i(
                             " from " + e.sourceClass + "." + e.sourceMethod.name);
                     String methodName = e.sourceClass.replace("/", "_") + "_" + e.sourceMethod.name;
+                    chain.collectAnnotations(e.threadLocalNode());
                     chain.next(owner, Opcodes.ACC_STATIC, methodName, staticDesc, e.threadLocalNode(), cv);
                 });
                 chain.fakePreMethod(getContext().name, access, name, desc, signature, exceptions);
 
-                return super.visitMethod(newAccess, newName, desc, signature, exceptions);
+                // 移除 原方法注解
+                return new AnnotationStrippingMethodVisitor(
+                        super.visitMethod(newAccess, newName, desc, signature, exceptions)
+                );
             }
         }
         return super.visitMethod(access, name, desc, signature, exceptions);
@@ -98,5 +102,32 @@ public class InsertClassVisitor extends LinkedClassVisitor {
 
         }
         super.visitEnd();
+    }
+
+    private class AnnotationStrippingMethodVisitor extends MethodVisitor {
+        public AnnotationStrippingMethodVisitor(MethodVisitor methodVisitor) {
+            super(Opcodes.ASM6,methodVisitor);
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+//            return super.visitAnnotation(descriptor, visible);
+            Log.tag("transform").d("Stripping annotation: " + descriptor);
+            //丢弃注解
+            return null;
+        }
+        @Override
+        public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath,
+                                                     String descriptor, boolean visible) {
+            // 同样丢弃类型注解（Java 8+）
+            return null;
+        }
+
+        @Override
+        public AnnotationVisitor visitParameterAnnotation(int parameter,
+                                                          String descriptor, boolean visible) {
+            // 丢弃参数注解
+            return null;
+        }
     }
 }


### PR DESCRIPTION
目标方法带有注解时导致的异常 ,因为只是重命名了旧方法,并没有处理注解相关问题.需要在新创建的方法上加回原方法注解,并移除旧方法注解